### PR TITLE
feat: allow disabling of rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ inquirer
           value: "spacex",
           URL: "https://en.wikipedia.org/wiki/SpaceX",
           Description:
-            "Space Exploration Technologies Corp. (doing business as SpaceX) is an American spacecraft manufacturer, space launch provider, and a satellite communications corporation headquartered in Hawthorne, California. SpaceX was founded in 2002 by Elon Musk, with the goal of reducing space transportation costs to enable the colonization of Mars. SpaceX manufactures the Falcon 9 and Falcon Heavy launch vehicles, several rocket engines, Cargo Dragon, crew spacecraft, and Starlink communications satellites."
+            "Space Exploration Technologies Corp. (doing business as SpaceX) is an American spacecraft manufacturer, space launch provider, and a satellite communications corporation headquartered in Hawthorne, California. SpaceX was founded in 2002 by Elon Musk, with the goal of reducing space transportation costs to enable the colonization of Mars. SpaceX manufactures the Falcon 9 and Falcon Heavy launch vehicles, several rocket engines, Cargo Dragon, crew spacecraft, and Starlink communications satellites.",
+          disabled: true
         },
         {
           value: "starlink",
@@ -109,8 +110,9 @@ Each Column is an object with these keys:
 
 Each Row is an object with these keys:
 
-| Key          | Type   | Description                                                                        |
-|--------------|--------|------------------------------------------------------------------------------------|
-| value        | any    | this is the value to be returned if the row was selected                           |
-| *ColumnName* | string | for each column `name` (see [Column](#Column) section above),                      |
-|              |        | set the key as the column `name` and the value as the column contents for the row. |
+| Key          | Type    | Description                                                                        |
+|--------------|---------|------------------------------------------------------------------------------------|
+| value        | any     | this is the value to be returned if the row was selected                           |
+| disabled     | boolean | display the option, but do not allow the user to select it                         |
+| *ColumnName* | string  | for each column `name` (see [Column](#Column) section above),                      |
+|              |         | set the key as the column `name` and the value as the column contents for the row. |

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "scripts": {
     "test": "npm run eslint",
-    "eslint": "eslint src"
+    "eslint": "eslint src",
+    "eslint-fix": "eslint src --fix"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,23 @@ class TablePrompt extends Base {
     this.opt.colWidths.unshift(6)
 
     this.columns = new Choices(this.opt.columns, [])
-    this.pointer = 0
     this.rows = new Choices(this.opt.rows, [])
     this.values = this.rows.filter(() => true).map(() => undefined)
 
+    // Bail if no enabled rows
+    const enabledRows = this.opt.rows.filter(row => !row.disabled)
+    if (enabledRows.length <= 0) {
+      this.onEnd()
+    }
+
+    // Set starting pointer to first valid row
+    this.pointer = 0
+    if (this.rows.length > 0) {
+      if (this.rows.get(this.pointer).disabled) {
+        this.pointer = this.findNextChoice(1)
+      } 
+    }
+    
     this.pageSize = this.opt.pageSize || 5
   }
 
@@ -58,10 +71,27 @@ class TablePrompt extends Base {
     return [...new Set(this.values)].filter(j => j != null)
   }
 
-  onDownKey () {
-    const length = this.rows.realLength
+  /**
+   * Given an offset, find the next valid row, starting 
+   * at the current pointer position.
+   * @param {number} offset 
+   * @returns 
+   */
+  findNextChoice(offset) {
+    let newPointer = this.pointer
+    let selectedOption
+    const length = this.rows.length
 
-    this.pointer = this.pointer < length - 1 ? this.pointer + 1 : this.pointer
+    while (!selectedOption || selectedOption.disabled) {
+      newPointer =
+        (newPointer + offset + length) % length
+      selectedOption = this.rows.get(newPointer)
+    }
+    return newPointer
+  }
+ 
+  onDownKey () {
+    this.pointer = this.findNextChoice(1)
     this.render()
   }
 
@@ -96,7 +126,7 @@ class TablePrompt extends Base {
   }
 
   onUpKey () {
-    this.pointer = this.pointer > 0 ? this.pointer - 1 : this.pointer
+    this.pointer = this.findNextChoice(-1)
     this.render()
   }
 
@@ -105,7 +135,7 @@ class TablePrompt extends Base {
     const firstIndex = Math.max(0, this.pointer - middleOfPage)
     const lastIndex = Math.min(
       firstIndex + this.pageSize - 1,
-      this.rows.realLength - 1
+      this.rows.length - 1
     )
     const lastPageOffset = this.pageSize - 1 - lastIndex + firstIndex
 
@@ -158,10 +188,15 @@ class TablePrompt extends Base {
         const isSelected = this.pointer === rowIndex
 
         let value
-        if (this.values[rowIndex]) {
-          value = figures.radioOn
+
+        if (row.disabled) {
+          value = "-"
         } else {
-          value = figures.radioOff
+          if (this.values[rowIndex]) {
+            value = figures.radioOn
+          } else {
+            value = figures.radioOff
+          }
         }
 
         let cellValue

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ class TablePrompt extends Base {
     this.pointer = 0
     if (this.rows.length > 0) {
       if (this.rows.get(this.pointer).disabled) {
-        this.pointer = this.findNextChoice(1)
+        this.pointer = this.findNextRow(1)
       }
     }
 
@@ -72,13 +72,13 @@ class TablePrompt extends Base {
   }
 
   /**
-   * Given an offset, find the next valid row, starting
+   * Given an offset, find the next enabled row, starting
    * at the current pointer position.
    *
    * @param {number} offset Search offset
-   * @returns {number} Pointer to next valid row
+   * @returns {number} Pointer to next enabled row
    */
-  findNextChoice (offset) {
+  findNextRow (offset) {
     let newPointer = this.pointer
     let selectedOption
     const length = this.rows.length
@@ -92,7 +92,7 @@ class TablePrompt extends Base {
   }
 
   onDownKey () {
-    this.pointer = this.findNextChoice(1)
+    this.pointer = this.findNextRow(1)
     this.render()
   }
 
@@ -127,7 +127,7 @@ class TablePrompt extends Base {
   }
 
   onUpKey () {
-    this.pointer = this.findNextChoice(-1)
+    this.pointer = this.findNextRow(-1)
     this.render()
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,9 +30,9 @@ class TablePrompt extends Base {
     if (this.rows.length > 0) {
       if (this.rows.get(this.pointer).disabled) {
         this.pointer = this.findNextChoice(1)
-      } 
+      }
     }
-    
+
     this.pageSize = this.opt.pageSize || 5
   }
 
@@ -72,12 +72,13 @@ class TablePrompt extends Base {
   }
 
   /**
-   * Given an offset, find the next valid row, starting 
+   * Given an offset, find the next valid row, starting
    * at the current pointer position.
-   * @param {number} offset 
-   * @returns 
+   *
+   * @param {number} offset Search offset
+   * @returns {number} Pointer to next valid row
    */
-  findNextChoice(offset) {
+  findNextChoice (offset) {
     let newPointer = this.pointer
     let selectedOption
     const length = this.rows.length
@@ -89,7 +90,7 @@ class TablePrompt extends Base {
     }
     return newPointer
   }
- 
+
   onDownKey () {
     this.pointer = this.findNextChoice(1)
     this.render()
@@ -190,7 +191,7 @@ class TablePrompt extends Base {
         let value
 
         if (row.disabled) {
-          value = "-"
+          value = '-'
         } else {
           if (this.values[rowIndex]) {
             value = figures.radioOn


### PR DESCRIPTION
Add `disabled` option for rows. This allows rows to be displayed to the user, but not selected. 

## Related Issues
https://github.com/adobe/aio-cli-plugin-app/issues/590

## Screenshots (if appropriate):
<img width="642" alt="image" src="https://user-images.githubusercontent.com/28722775/193656738-d7c03668-5e3b-44bc-9e61-5d420b103937.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
